### PR TITLE
Update brew and replace react-native-apps with expo

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -117,7 +117,7 @@ alias npc='npm run precommit'
 
 alias pipup='pip freeze --local | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U'
 
-alias crna='create-react-native-app'
+alias crna='expo init'
 alias bpb='bundle-phobia'
 
 alias v="vim"

--- a/.wgetrc
+++ b/.wgetrc
@@ -1,0 +1,2 @@
+# Set default IRI support state
+iri = on

--- a/lib/apps
+++ b/lib/apps
@@ -9,7 +9,7 @@ run_apps() {
 	brew cask install default-folder-x
 	brew cask install dropbox
 	brew cask install google-backup-and-sync
-	brew cask install istat-menusq
+	brew cask install istat-menus
 	brew cask install little-snitch
 	brew cask install macupdater
 	brew cask install rocket

--- a/lib/brew
+++ b/lib/brew
@@ -25,7 +25,7 @@ run_brew() {
 	brew install bash-completion2 gem-completion docker-completion launchctl-completion wpcli-completion
 
 	# Install more recent versions of some OS X tools
-	brew install vim --override-system-vi
+	brew install vim
 	brew install grep
 	brew install screen
 
@@ -68,12 +68,12 @@ run_brew() {
 	brew install thefuck
 	brew install httpie
 	brew install jq
-	brew install imagemagick --with-webp
+	brew install imagemagick
 	brew install lame
 	brew install rename
 	brew install tree
 	brew install watchman
-	brew install wget --with-iri
+	brew install wget
 	brew install wp-cli
 
 	# Install code review tools

--- a/lib/dotfiles
+++ b/lib/dotfiles
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-dotfiles=(.ackrc .aliases .bash_colors .bash_completion .bash_profile .bash_prompt .bashrc .editorconfig .exports .functions .gitattributes .gitconfig .gitignore .inputrc .npmrc .osx .vim .vimrc)
+dotfiles=(.ackrc .aliases .bash_colors .bash_completion .bash_profile .bash_prompt .bashrc .editorconfig .exports .functions .gitattributes .gitconfig .gitignore .inputrc .npmrc .osx .vim .vimrc .wgetrc)
 
 # Install dotfiles
 run_dotfiles() {

--- a/lib/npm
+++ b/lib/npm
@@ -15,9 +15,9 @@ npm_packages=(
 	codesandbox
 	create-next-app
 	create-react-app
-	create-react-native-app
 	dotenv
 	eslint
+	expo-cli
 	flow-bin
 	gatsby-cli
 	gitbook-cli


### PR DESCRIPTION
### Using expo-cli in favor of create-react-native-app

create-react-native-app repo is currently archived. New issues are being redirected to expo repo. So I've add expo-cli to the npm file and updated it's alias.

### Removing Homebrew parameters

Homebrew currently does not accepts params to formulas anymore. So, I removed them from the brew file.

[Vim's formula](https://github.com/Homebrew/homebrew-core/blob/f779136c9bd17d14f219010edfa4fdcb3ef8241f/Formula/vim.rb#L64) already sets the default vi client as vim. 

[Imagemagick's formula](https://github.com/Homebrew/homebrew-core/blob/f779136c9bd17d14f219010edfa4fdcb3ef8241f/Formula/imagemagick.rb#L48) also sets `--with-webp` to the config.

[Wget's docs](https://www.gnu.org/software/wget/manual/wget.html) says IRI support is on by default. But to make it sure, I've also added it to a new .wgetrc file.